### PR TITLE
Fix typed dictionary ref resolution

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -192,6 +192,16 @@ end
 
 build_id_map!(::AbstractDict, ::Any, ::URIs.URI) = nothing
 
+_copy_schema(x) = deepcopy(x)
+
+function _copy_schema(schema::Vector)
+    return map(_copy_schema, schema)
+end
+
+function _copy_schema(schema::Dict{K}) where {K}
+    return Dict{K,Any}(k => _copy_schema(v) for (k, v) in schema)
+end
+
 function build_id_map!(
     id_map::AbstractDict,
     schema::AbstractVector,
@@ -257,7 +267,7 @@ struct Schema
             )
             parent_dir = parentFileDirectory
         end
-        schema = deepcopy(schema)  # Ensure we don't modify the user's data!
+        schema = _copy_schema(schema)  # Ensure we don't modify the user's data!
         id_map = build_id_map(schema)
         resolve_refs!(schema, URIs.URI(), id_map, parent_dir)
         return new(schema)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,6 +228,18 @@ end
     schema_2 = JSONSchema.Schema(false)
     @test typeof(schema_2) == Schema
     @test typeof(schema_2.data) == Bool
+
+    schema_dict = Dict(
+        "properties" =>
+            Dict("age" => Dict("\$ref" => "#/\$defs/positiveNumber")),
+        "\$defs" => Dict(
+            "positiveNumber" => Dict("type" => "number", "minimum" => 0),
+        ),
+    )
+    schema = JSONSchema.Schema(schema_dict)
+    @test isvalid(schema, Dict("age" => 1))
+    @test !isvalid(schema, Dict("age" => -1))
+    @test schema_dict["properties"]["age"]["\$ref"] == "#/\$defs/positiveNumber"
 end
 
 @testset "Base.show" begin


### PR DESCRIPTION
## Summary
- Copy Base `Dict` schema inputs into widened `Dict{K,Any}` containers before resolving refs.
- Preserve parsed JSON object behavior by leaving non-`Dict` schema containers on the existing `deepcopy` path.
- Add a regression test for issue #81 covering a strictly typed nested dictionary and ensuring the caller's input remains unchanged.

## Root Cause
`Schema(::AbstractDict)` deep-copied user input without widening nested `Dict` value types. During `$ref` expansion, the resolver replaces a string ref with the referenced schema dictionary, which fails for nested dictionaries inferred as `Dict{String,String}`.

Fixes #81

## Validation
- `julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`

Co-authored by Codex